### PR TITLE
説明が逆転しているので修正

### DIFF
--- a/Doc/firmware_jp.md
+++ b/Doc/firmware_jp.md
@@ -40,18 +40,18 @@ RGBバックライトとUnderglowは、共にQMKの[RGB Lighting](https://docs.q
 次に config.h で使用するLEDの数と最大の明るさを設定します。
 最大の明るさを下記の推奨値以下にしないと消費電流が大きくなり過ぎますのでご注意ください。
 
-バックライトの時
+Underglowの時
 
     #define RGBLED_NUM 6
     #define RGBLIGHT_LIMIT_VAL 255
 
-Underglow（5行）の時
+バックライト（5行）の時
 
     #define RGBLED_NUM 32
     #define RGBLIGHT_LIMIT_VAL 120
 
 
-Underglow（4行）の時
+バックライト（4行）の時
 
     #define RGBLED_NUM 25
     #define RGBLIGHT_LIMIT_VAL 130


### PR DESCRIPTION
Underglowとバックライトの説明が逆転しているので修正しました。