### PR TITLE
Specify version 7 when installing avr-gcc with brew of macOS.

### DIFF
--- a/Doc/firmware_jp.md
+++ b/Doc/firmware_jp.md
@@ -46,7 +46,7 @@ gitに慣れている方はクローンの方が良いでしょう。
 brew tap osx-cross/avr
 brew tap PX4/homebrew-px4
 brew update
-brew install avr-gcc
+brew install avr-gcc@7
 brew install dfu-programmer
 brew install gcc-arm-none-eabi
 brew install avrdude


### PR DESCRIPTION
see: https://github.com/qmk/qmk_firmware/pull/3337